### PR TITLE
refactor: data/サブディレクトリ名を整理（generated/presets/scenes）

### DIFF
--- a/src/plugins/image_gen/index.ts
+++ b/src/plugins/image_gen/index.ts
@@ -10,10 +10,10 @@ const router = Router();
 
 const GEMINI_KEY = process.env.GEMINI_API_KEY ?? '';
 const GEN_SCRIPT = path.join(__dirname, 'gen.js');
-const OUT_DIR = '/home/node/.openclaw/workspace/data/generated_images';
+const OUT_DIR = '/home/node/.openclaw/workspace/data/generated';
 const CASTS_DIR = '/home/node/.openclaw/workspace/data/casts';
-const IMAGE_GEN_DATA = '/home/node/.openclaw/workspace/data/image_gen';
-const SCENE_DIR = '/home/node/.openclaw/workspace/data/scene';
+const IMAGE_GEN_DATA = '/home/node/.openclaw/workspace/data/presets';
+const SCENE_DIR = '/home/node/.openclaw/workspace/data/scenes';
 if (!fs.existsSync(SCENE_DIR)) fs.mkdirSync(SCENE_DIR, { recursive: true });
 
 function loadPresets() {


### PR DESCRIPTION
## 概要

data/ サブディレクトリ名をセマンティックに統一

## 変更

| 旧 | 新 | 理由 |
|---|---|---|
| `data/image_gen/` | `data/presets/` | 画像限定でなく汎用プリセット置き場 |
| `data/generated_images/` | `data/generated/` | 画像限定でなく生成物全般 |
| `data/scene/` | `data/scenes/` | 複数形で統一 |

## 完成形

```
data/
  assets/      ← asset_viewer
  casts/       ← cast_manager
  docs/        ← document_viewer
  generated/   ← 生成物全般（画像・テキスト等）
  presets/     ← 汎用プリセット（touch/model等）
  scenes/      ← 背景画像
```

---
*実装: メフィ（CCO）😈 — 2026-03-08*