### PR TITLE
refactor: UI絵文字アイコンをFont Awesomeに統一（たたき台）

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -32,6 +32,7 @@ const loginPage = (error = '') => `<!DOCTYPE html>
 <html><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${NAME} — Login</title>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 <style>
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:-apple-system,sans-serif;background:#1a1a2e;color:#e0e0e0;
@@ -48,7 +49,7 @@ const loginPage = (error = '') => `<!DOCTYPE html>
   .error{color:#e94560;font-size:.85em;margin-bottom:12px}
 </style></head><body>
 <div class="box">
-  <h1>🏭 ${NAME}</h1>
+  <h1><i class="fas fa-industry"></i> ${NAME}</h1>
   ${AGENT ? `<div class="agent">${AGENT}</div>` : ''}
   ${error ? `<div class="error">${error}</div>` : ''}
   <form method="post" action="${url('/login')}">
@@ -83,7 +84,7 @@ router.get('/logout', (req, res) => {
 router.get('/', requireAuth, (_req, res) => {
   const cards = registry.map(p => `
     <a href="${url(p.url)}" class="card">
-      <div class="icon">${p.icon}</div>
+      <div class="icon"><i class="${p.icon}"></i></div>
       <div class="name">${p.name}<span class="badge">${p.layer}</span></div>
       <div class="desc">${p.desc}</div>
     </a>`).join('');
@@ -92,6 +93,7 @@ router.get('/', requireAuth, (_req, res) => {
 <html><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${NAME}</title>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 <style>
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:-apple-system,sans-serif;background:#1a1a2e;color:#e0e0e0;min-height:100vh}
@@ -114,7 +116,7 @@ router.get('/', requireAuth, (_req, res) => {
   .empty{color:#888}
 </style></head><body>
 <div class="header">
-  <h1>🏭 ${NAME}</h1>
+  <h1><i class="fas fa-industry"></i> ${NAME}</h1>
   <div class="meta">
     ${AGENT ? `<span>${AGENT}</span>` : ''}
     <a href="${url('/logout')}">ログアウト</a>

--- a/src/plugins/asset_viewer/index.ts
+++ b/src/plugins/asset_viewer/index.ts
@@ -30,7 +30,7 @@ function getKind(filename: string): AssetKind {
 }
 
 function kindIcon(kind: AssetKind) {
-  return { image: '🖼', video: 'video', model: 'model', other: 'file' }[kind];
+  return { image: 'fas fa-image', video: 'fas fa-video', model: 'fas fa-cube', other: 'fas fa-file' }[kind];
 }
 
 function safeJoin(base: string, rel: string): string | null {
@@ -46,6 +46,7 @@ function layout(title: string, body: string): string {
   return `<!DOCTYPE html>
 <html><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 <title>${title} — labo-portal</title>
 <script type="module" src="https://ajax.googleapis.com/ajax/libs/model-viewer/4.0.0/model-viewer.min.js"></script>
 <style>
@@ -142,7 +143,7 @@ router.get('/', requireAuth, (req, res) => {
       ? `<img src="${url('/assets/raw')}?path=${encodeURIComponent(childRel)}" alt="${e.name}" loading="lazy">`
       : e.kind === 'video'
       ? `<video src="${url('/assets/raw')}?path=${encodeURIComponent(childRel)}" muted></video>`
-      : `<span class="icon-big">${kindIcon(e.kind)}</span>`;
+      : `<span class="icon-big"><i class="${kindIcon(e.kind)}"></i></span>`;
 
     return `
       <div class="asset-card" style="position:relative">
@@ -150,7 +151,7 @@ router.get('/', requireAuth, (req, res) => {
           <div class="asset-thumb">${thumb}</div>
           <div class="asset-info">
             <div class="asset-name">${e.name}</div>
-            <div class="asset-kind">${kindIcon(e.kind)} ${e.kind}</div>
+            <div class="asset-kind"><i class="${kindIcon(e.kind)}"></i> ${e.kind}</div>
           </div>
         </a>
         <form method="post" action="${url('/assets/delete')}"
@@ -233,7 +234,7 @@ router.get('/view', requireAuth, (req, res) => {
             style="width:32px;height:32px;background:rgba(233,69,96,0.9);color:#fff;border:none;border-radius:50%;font-size:1.1em;font-weight:700;cursor:pointer;line-height:1;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 6px rgba(0,0,0,.5)">✕</button>
         </form>
       </div>` : `<div class="preview-wrap">${preview}</div>`}
-      <div class="meta-row" style="margin-top:12px">${kindIcon(kind)} ${kind} &nbsp;|&nbsp; ${sizeKB} KB &nbsp;|&nbsp; ${filename}</div>
+      <div class="meta-row" style="margin-top:12px"><i class="${kindIcon(kind)}"></i> ${kind} &nbsp;|&nbsp; ${sizeKB} KB &nbsp;|&nbsp; ${filename}</div>
       <div class="actions" style="margin-top:16px;display:flex;align-items:center;gap:12px;flex-wrap:wrap">
         <a href="${rawUrl}" download="${filename}" class="actions a btn-dl">⬇ ダウンロード</a>
         <a href="${url('/assets')}?path=${encodeURIComponent(dirRel)}" class="actions a btn-back">← 戻る</a>
@@ -363,7 +364,7 @@ router.post('/upload', requireAuth, (req, res) => {
         <p style="color:#50fa7b;margin-bottom:16px">✅ アップロード完了</p>
         ${kind === 'image'
           ? `<img src="${url('/assets/raw')}?path=${encodeURIComponent(previewPath)}" style="max-width:100%;max-height:400px;border-radius:8px;border:1px solid #0f3460">`
-          : `<p style="color:#aaa">${kindIcon(kind)} ${f.filename}</p>`
+          : `<p style="color:#aaa"><i class="${kindIcon(kind)}"></i> ${f.filename}</p>`
         }
         <div style="margin-top:16px;display:flex;gap:12px;flex-wrap:wrap">
           <a href="${url('/assets/view')}?path=${encodeURIComponent(previewPath)}" style="padding:8px 18px;background:#0f3460;color:#8be9fd;border-radius:6px;text-decoration:none;font-weight:600">プレビュー</a>

--- a/src/plugins/asset_viewer/index.ts
+++ b/src/plugins/asset_viewer/index.ts
@@ -30,7 +30,7 @@ function getKind(filename: string): AssetKind {
 }
 
 function kindIcon(kind: AssetKind) {
-  return { image: '🖼', video: '🎬', model: '📦', other: '📎' }[kind];
+  return { image: '🖼', video: 'video', model: 'model', other: 'file' }[kind];
 }
 
 function safeJoin(base: string, rel: string): string | null {
@@ -132,7 +132,7 @@ router.get('/', requireAuth, (req, res) => {
 
   const dirItems = dirs.map(e => {
     const childRel = rel ? `${rel}/${e.name}` : e.name;
-    return `<li><a href="${url('/assets')}?path=${encodeURIComponent(childRel)}"><span>📁</span>${e.name}/</a></li>`;
+    return `<li><a href="${url('/assets')}?path=${encodeURIComponent(childRel)}"><span class="icon"><i class="fas fa-folder"></i></span>${e.name}/</a></li>`;
   }).join('');
 
   const fileCards = files.map(e => {
@@ -166,7 +166,7 @@ router.get('/', requireAuth, (req, res) => {
 
   const body = `
     <div class="header">
-      <a href="${url('/')}">🏭 labo-portal</a>
+      <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
       <span class="sep">›</span>
       <span class="bc">${crumbs}</span>
     </div>
@@ -214,7 +214,7 @@ router.get('/view', requireAuth, (req, res) => {
 
   const body = `
     <div class="header">
-      <a href="${url('/')}">🏭 labo-portal</a>
+      <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
       <span class="sep">›</span>
       <a class="bc" href="${url('/assets')}?path=${encodeURIComponent(dirRel)}">${dirRel || 'assets'}</a>
       <span class="sep">›</span>
@@ -245,7 +245,7 @@ router.get('/view', requireAuth, (req, res) => {
           <input type="hidden" name="path" value="${rel}">
           <input type="hidden" name="back" value="${dirRel}">
           <button type="submit"
-            style="padding:8px 18px;background:#3a0010;color:#e94560;border:1px solid #660020;border-radius:6px;font-size:.9em;font-weight:600;cursor:pointer">🗑 削除</button>
+            style="padding:8px 18px;background:#3a0010;color:#e94560;border:1px solid #660020;border-radius:6px;font-size:.9em;font-weight:600;cursor:pointer"> <i class="fas fa-trash"></i> 削除</button>
         </form>` : ''}
       </div>
     </div>`;
@@ -289,9 +289,9 @@ router.get('/upload', requireAuth, (req, res) => {
   const destPath = (req.query.path as string ?? '');
   const body = `
     <div class="header">
-      <a href="${url('/')}">🏭 labo-portal</a>
+      <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
       <span class="sep">›</span>
-      <a href="${url('/assets')}">🖼 アセット</a>
+      <a href="${url('/assets')}"> <i class="fas fa-images"></i> アセット</a>
       <span class="sep">›</span>
       <span>アップロード</span>
     </div>
@@ -347,7 +347,7 @@ router.post('/upload', requireAuth, (req, res) => {
   assetUpload.single('file')(req, res, (err) => {
     if (err) {
       return res.status(400).send(layout('エラー', `
-        <div class="header"><a href="${url('/')}">🏭 labo-portal</a><span class="sep">›</span><a href="${url('/assets')}">🖼 アセット</a></div>
+        <div class="header"><a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a><span class="sep">›</span><a href="${url('/assets')}"> <i class="fas fa-images"></i> アセット</a></div>
         <div class="main">
           <p style="color:#e94560;background:#1a0010;border:1px solid #e94560;border-radius:6px;padding:12px">${err.message}</p>
           <p style="margin-top:12px"><a href="${url('/assets/upload')}" style="color:#e94560">← 戻る</a></p>
@@ -358,7 +358,7 @@ router.post('/upload', requireAuth, (req, res) => {
     const previewPath = `uploads/${f.filename}`;
 
     res.send(layout('完了', `
-      <div class="header"><a href="${url('/')}">🏭 labo-portal</a><span class="sep">›</span><a href="${url('/assets')}">🖼 アセット</a></div>
+      <div class="header"><a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a><span class="sep">›</span><a href="${url('/assets')}"> <i class="fas fa-images"></i> アセット</a></div>
       <div class="main" style="max-width:720px">
         <p style="color:#50fa7b;margin-bottom:16px">✅ アップロード完了</p>
         ${kind === 'image'

--- a/src/plugins/asset_viewer/index.ts
+++ b/src/plugins/asset_viewer/index.ts
@@ -376,7 +376,7 @@ router.post('/upload', requireAuth, (req, res) => {
 
 export const meta = {
   name: 'Asset Viewer',
-  icon: '🖼',
+  icon: 'fas fa-images',
   desc: '画像・動画・3Dモデルの表示＆アップロード',
   layer: 'core' as const,
   url: '/assets',

--- a/src/plugins/cast_manager/index.ts
+++ b/src/plugins/cast_manager/index.ts
@@ -332,7 +332,7 @@ router.post('/:id/delete', requireAuth, (req, res) => {
 
 export const meta = {
   name: 'キャスト',
-  icon: '🎭',
+  icon: 'fas fa-masks-theater',
   desc: 'キャラクター管理（画像・プロンプトセット）',
   layer: 'layer2' as const,
   url: '/cast_manager',

--- a/src/plugins/cast_manager/index.ts
+++ b/src/plugins/cast_manager/index.ts
@@ -118,7 +118,7 @@ function layout(title: string, body: string): string {
 
 function headerHtml(sub?: string): string {
   return `<div class="header">
-    <a href="${url('/')}">🏭 labo-portal</a>
+    <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
     <span class="sep">›</span>
     <a href="${url('/cast_manager')}">🎭 キャスト</a>
     ${sub ? `<span class="sep">›</span><span>${sub}</span>` : ''}
@@ -287,7 +287,7 @@ router.post('/new', requireAuth,
 router.get('/:id/edit', requireAuth, (req, res) => {
   const profile = loadProfile(req.params.id);
   if (!profile) return res.redirect(url('/cast_manager'));
-  const body = `${headerHtml('編集')}<div class="main"><h2>✏️ ${profile.name} を編集</h2>${profileForm('/cast_manager/' + req.params.id + '/edit', profile, req.params.id)}</div>`;
+  const body = `${headerHtml('編集')}<div class="main"><h2> <i class="fas fa-edit"></i> ${profile.name} を編集</h2>${profileForm('/cast_manager/' + req.params.id + '/edit', profile, req.params.id)}</div>`;
   res.send(layout('編集', body));
 });
 

--- a/src/plugins/cast_manager/index.ts
+++ b/src/plugins/cast_manager/index.ts
@@ -74,6 +74,7 @@ function layout(title: string, body: string): string {
   return `<!DOCTYPE html>
 <html><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 <title>${title} — labo-portal</title>
 <style>
   *{box-sizing:border-box;margin:0;padding:0}
@@ -120,7 +121,7 @@ function headerHtml(sub?: string): string {
   return `<div class="header">
     <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
     <span class="sep">›</span>
-    <a href="${url('/cast_manager')}">🎭 キャスト</a>
+    <a href="${url('/cast_manager')}">  <i class="fas fa-masks-theater"></i> キャスト</a>
     ${sub ? `<span class="sep">›</span><span>${sub}</span>` : ''}
   </div>`;
 }
@@ -164,7 +165,7 @@ router.get('/', requireAuth, (req, res) => {
     ${headerHtml()}
     <div class="main">
       <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:20px">
-        <h2>🎭 キャスト管理</h2>
+        <h2><i class="fas fa-masks-theater"></i> キャスト管理</h2>
         <a href="${url('/cast_manager/new')}" class="btn btn-primary">＋ 新規キャスト</a>
       </div>
       ${msg === 'saved' ? '<div class="alert alert-ok">✅ 保存しました</div>' : ''}

--- a/src/plugins/document_viewer/index.ts
+++ b/src/plugins/document_viewer/index.ts
@@ -102,7 +102,7 @@ router.get('/', requireAuth, (req, res) => {
 
   const body = `
     <div class="header">
-      <a href="${url('/')}">🏭 labo-portal</a>
+      <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
       <span class="sep">›</span>
       <span class="bc">${crumbs}</span>
       <span style="flex:1"></span>
@@ -137,7 +137,7 @@ router.get('/view', requireAuth, (req, res) => {
 
   const body = `
     <div class="header">
-      <a href="${url('/')}">🏭 labo-portal</a>
+      <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
       <span class="sep">›</span>
       <a class="bc" href="${url('/docs')}?path=${encodeURIComponent(dirRel)}">${dirRel}</a>
       <span class="sep">›</span>
@@ -151,7 +151,7 @@ router.get('/view', requireAuth, (req, res) => {
         <input type="hidden" name="path" value="${rel}">
         <input type="hidden" name="back" value="${dirRel}">
         <button type="submit"
-          style="padding:6px 14px;background:#3a0010;color:#e94560;border:1px solid #660020;border-radius:5px;font-size:.82em;font-weight:600;cursor:pointer">🗑 削除</button>
+          style="padding:6px 14px;background:#3a0010;color:#e94560;border:1px solid #660020;border-radius:5px;font-size:.82em;font-weight:600;cursor:pointer"> <i class="fas fa-trash"></i> 削除</button>
       </form>
     </div>
     <div class="main">
@@ -195,9 +195,9 @@ router.get('/upload', requireAuth, (req, res) => {
   const destPath = req.query.path as string ?? '';
   res.send(layout('アップロード', `
     <div class="header">
-      <a href="${url('/')}">🏭 labo-portal</a>
+      <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
       <span class="sep">›</span>
-      <a href="${url('/docs')}">📄 ドキュメント</a>
+      <a href="${url('/docs')}"> <i class="fas fa-file-alt"></i> ドキュメント</a>
       <span class="sep">›</span>
       <span>アップロード</span>
     </div>
@@ -250,7 +250,7 @@ router.post('/upload', requireAuth, (req, res) => {
   docUpload.single('file')(req, res, (err) => {
     if (err) {
       return res.status(400).send(layout('エラー', `
-        <div class="header"><a href="${url('/')}">🏭 labo-portal</a><span class="sep">›</span><a href="${url('/docs')}">📄 ドキュメント</a></div>
+        <div class="header"><a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a><span class="sep">›</span><a href="${url('/docs')}"> <i class="fas fa-file-alt"></i> ドキュメント</a></div>
         <div class="main">
           <p style="color:#e94560;background:#1a0010;border:1px solid #e94560;border-radius:6px;padding:12px">${err.message}</p>
           <p style="margin-top:12px"><a href="${url('/docs/upload')}" style="color:#e94560">← 戻る</a></p>
@@ -258,7 +258,7 @@ router.post('/upload', requireAuth, (req, res) => {
     }
     const f = (req as any).file;
     res.send(layout('完了', `
-      <div class="header"><a href="${url('/')}">🏭 labo-portal</a><span class="sep">›</span><a href="${url('/docs')}">📄 ドキュメント</a></div>
+      <div class="header"><a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a><span class="sep">›</span><a href="${url('/docs')}"> <i class="fas fa-file-alt"></i> ドキュメント</a></div>
       <div class="main">
         <p style="color:#50fa7b;margin-bottom:16px">✅ アップロード完了: ${f.filename}</p>
         <p><a href="${url('/docs')}?path=uploads/docs" style="color:#8be9fd">アップロードフォルダを開く</a>

--- a/src/plugins/document_viewer/index.ts
+++ b/src/plugins/document_viewer/index.ts
@@ -21,6 +21,7 @@ function layout(title: string, body: string): string {
   return `<!DOCTYPE html>
 <html><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 <title>${title} — labo-portal</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.5.0/github-markdown-dark.min.css">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/11.1.1/marked.min.js"></script>

--- a/src/plugins/document_viewer/index.ts
+++ b/src/plugins/document_viewer/index.ts
@@ -269,7 +269,7 @@ router.post('/upload', requireAuth, (req, res) => {
 
 export const meta = {
   name: 'Document Viewer',
-  icon: '📄',
+  icon: 'fas fa-file-alt',
   desc: 'Markdown・テキスト・設定ファイルを表示＆アップロード',
   layer: 'core' as const,
   url: '/docs',

--- a/src/plugins/image_gen/index.ts
+++ b/src/plugins/image_gen/index.ts
@@ -119,6 +119,7 @@ function layout(title: string, body: string): string {
   return `<!DOCTYPE html>
 <html><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 <title>${title} — labo-portal</title>
 <style>
   *{box-sizing:border-box;margin:0;padding:0}
@@ -223,8 +224,8 @@ router.get('/cast-avatar/:id/:file', requireAuth, (req, res) => {
 // ── GET: フォーム ─────────────────────────────────
 router.get('/', requireAuth, (_req, res) => {
   if (!GEMINI_KEY) {
-    const body = `<div class="header"><a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a><span class="sep">›</span><span>🎨 画像生成</span></div>
-      <div class="main"><h2>🎨 Imagen 画像生成</h2><div class="error">GEMINI_API_KEY が設定されていません。</div></div>`;
+    const body = `<div class="header"><a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a><span class="sep">›</span><span>  <i class="fas fa-palette"></i> 画像生成</span></div>
+      <div class="main"><h2><i class="fas fa-palette"></i> Imagen 画像生成</h2><div class="error">GEMINI_API_KEY が設定されていません。</div></div>`;
     return res.send(layout('画像生成', body));
   }
 
@@ -251,15 +252,15 @@ router.get('/', requireAuth, (_req, res) => {
     <div class="header">
       <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
       <span class="sep">›</span>
-      <span>🎨 画像生成</span>
+      <span>  <i class="fas fa-palette"></i> 画像生成</span>
     </div>
     <div class="main">
-      <h2>🎨 Imagen 画像生成</h2>
+      <h2><i class="fas fa-palette"></i> Imagen 画像生成</h2>
       <form method="post" action="${url('/image_gen')}" id="form">
 
         <!-- キャスト選択（複数） -->
         <div class="card">
-          <h3>🎭 キャスト（任意・複数可）</h3>
+          <h3><i class="fas fa-masks-theater"></i> キャスト（任意・複数可）</h3>
           <div id="castRows"></div>
           <button type="button" id="btnAddCast" class="btn btn-copy" style="margin-top:8px;font-size:.82em">＋ キャスト追加</button>
           <p class="hint" style="margin-top:6px">複数選択時はプロンプトでA/B/Cと指定: "A is standing, B is next to A"</p>
@@ -441,16 +442,16 @@ router.post('/', requireAuth, (req, res) => {
   execFile('node', args, { timeout: 90000, env: { ...process.env, HOME: '/home/node' } }, (err, _stdout, stderr) => {
     if (err || !fs.existsSync(outPath)) {
       const body = `<div class="header"><a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a><span class="sep">›</span>
-        <a href="${url('/image_gen')}">🎨 画像生成</a></div>
-        <div class="main"><h2>🎨 生成エラー</h2>
+        <a href="${url('/image_gen')}">  <i class="fas fa-palette"></i> 画像生成</a></div>
+        <div class="main"><h2><i class="fas fa-palette"></i> 生成エラー</h2>
           <div class="error">${err?.message ?? 'Unknown error'}<br>
             <pre style="margin-top:8px;font-size:.85em;white-space:pre-wrap">${stderr}</pre></div>
           <p style="margin-top:16px"><a href="${url('/image_gen')}" style="color:#e94560">← 戻る</a></p></div>`;
       return res.send(layout('生成エラー', body));
     }
     const body = `<div class="header"><a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a><span class="sep">›</span>
-      <a href="${url('/image_gen')}">🎨 画像生成</a></div>
-      <div class="main"><h2>🎨 生成完了</h2>
+      <a href="${url('/image_gen')}">  <i class="fas fa-palette"></i> 画像生成</a></div>
+      <div class="main"><h2><i class="fas fa-palette"></i> 生成完了</h2>
         <div class="img-wrap"><img src="${url('/image_gen/img/' + filename)}" alt="generated">
           <p class="prompt-echo">「${prompt.replace(/</g,'&lt;').slice(0,120)}${prompt.length>120?'…':''}」</p></div>
         <div style="display:flex;gap:16px;margin-top:20px;flex-wrap:wrap">
@@ -776,7 +777,7 @@ router.get('/client.js', requireAuth, (req, res) => {
         .then(function(r) { return r.json(); })
         .then(function(d) {
           btnGen.disabled = false;
-          btnGen.textContent = '🎨 生成する';
+          btnGen.textContent = '<i class="fas fa-palette"></i> 生成する';
           if (d.ok) {
             if (resultImg) resultImg.src = d.imgUrl;
             if (resultDownload) { resultDownload.href = d.downloadUrl; resultDownload.download = d.filename; }
@@ -792,7 +793,7 @@ router.get('/client.js', requireAuth, (req, res) => {
         })
         .catch(function(e) {
           btnGen.disabled = false;
-          btnGen.textContent = '🎨 生成する';
+          btnGen.textContent = '<i class="fas fa-palette"></i> 生成する';
           if (resultError) { resultError.textContent = 'ネットワークエラー: ' + e.message; resultError.style.display = 'block'; }
           if (resultPanel) resultPanel.style.display = 'block';
         });

--- a/src/plugins/image_gen/index.ts
+++ b/src/plugins/image_gen/index.ts
@@ -335,9 +335,9 @@ router.get('/', requireAuth, (_req, res) => {
         <input type="hidden" name="final_prompt" id="finalPrompt">
 
         <div style="display:flex;gap:12px;align-items:center;flex-wrap:wrap">
-          <button type="button" id="btnPreview" class="btn btn-copy">🔍 プロンプト確認</button>
-          <button type="button" id="btnCopy" class="btn btn-copy" style="display:none">📋 コピー</button>
-          <button type="button" id="btnGen" class="btn btn-primary">🎨 生成する</button>
+          <button type="button" id="btnPreview" class="btn btn-copy"><i class="fas fa-search"></i> プロンプト確認</button>
+          <button type="button" id="btnCopy" class="btn btn-copy" style="display:none"><i class="fas fa-copy"></i> コピー</button>
+          <button type="button" id="btnGen" class="btn btn-primary"><i class="fas fa-palette"></i> 生成する</button>
         </div>
         <p class="hint" style="margin-top:8px">生成には10〜30秒かかります</p>
       </form>
@@ -815,7 +815,7 @@ router.get('/img/:filename', requireAuth, (req, res) => {
 
 export const meta = {
   name: '画像生成',
-  icon: '🎨',
+  icon: 'fas fa-palette',
   desc: 'Imagenで画像生成（キャスト選択・dry-run対応）',
   layer: 'layer2' as const,
   url: '/image_gen',

--- a/src/plugins/image_gen/index.ts
+++ b/src/plugins/image_gen/index.ts
@@ -223,7 +223,7 @@ router.get('/cast-avatar/:id/:file', requireAuth, (req, res) => {
 // ── GET: フォーム ─────────────────────────────────
 router.get('/', requireAuth, (_req, res) => {
   if (!GEMINI_KEY) {
-    const body = `<div class="header"><a href="${url('/')}">🏭 labo-portal</a><span class="sep">›</span><span>🎨 画像生成</span></div>
+    const body = `<div class="header"><a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a><span class="sep">›</span><span>🎨 画像生成</span></div>
       <div class="main"><h2>🎨 Imagen 画像生成</h2><div class="error">GEMINI_API_KEY が設定されていません。</div></div>`;
     return res.send(layout('画像生成', body));
   }
@@ -249,7 +249,7 @@ router.get('/', requireAuth, (_req, res) => {
 
   const body = `
     <div class="header">
-      <a href="${url('/')}">🏭 labo-portal</a>
+      <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
       <span class="sep">›</span>
       <span>🎨 画像生成</span>
     </div>
@@ -268,7 +268,7 @@ router.get('/', requireAuth, (_req, res) => {
 
         <!-- 背景シーン -->
         <div class="card">
-          <h3>🖼 背景シーン（任意）</h3>
+          <h3> <i class="fas fa-images"></i> 背景シーン（任意）</h3>
           <div style="display:flex;gap:12px;align-items:flex-end;flex-wrap:wrap">
             <div style="flex:1;min-width:200px">
               <label>背景画像</label>
@@ -283,14 +283,14 @@ router.get('/', requireAuth, (_req, res) => {
             <div>
               <label>画像をアップロード</label>
               <input type="file" id="sceneUploadInput" accept="image/*" style="display:none">
-              <button type="button" id="btnSceneUpload" class="btn btn-copy" style="font-size:.82em">📁 追加</button>
+              <button type="button" id="btnSceneUpload" class="btn btn-copy" style="font-size:.82em"> <i class="fas fa-folder"></i> 追加</button>
             </div>
           </div>
         </div>
 
         <!-- カメラ & タッチ -->
         <div class="card">
-          <h3>🎬 カメラ & タッチ</h3>
+          <h3>video カメラ & タッチ</h3>
           <div style="display:flex;gap:12px;flex-wrap:wrap">
             <div style="flex:1;min-width:180px">
               <label>カメラ（AIモデル）</label>
@@ -320,7 +320,7 @@ router.get('/', requireAuth, (_req, res) => {
 
         <!-- シーン・追加プロンプト -->
         <div class="card">
-          <h3>✍️ プロンプト</h3>
+          <h3> <i class="fas fa-pen"></i> プロンプト</h3>
           <label id="sceneLabel">シーン・ポーズ・追加指示</label>
           <textarea name="scene" id="sceneInput" rows="4" placeholder="standing in a library, looking at camera, slight smile..."></textarea>
           <p class="hint" id="sceneHint">キャスト選択時はベースプロンプトに追加されます</p>
@@ -440,7 +440,7 @@ router.post('/', requireAuth, (req, res) => {
   console.log('[image_gen] POST / prompt:', prompt.slice(0, 80));
   execFile('node', args, { timeout: 90000, env: { ...process.env, HOME: '/home/node' } }, (err, _stdout, stderr) => {
     if (err || !fs.existsSync(outPath)) {
-      const body = `<div class="header"><a href="${url('/')}">🏭 labo-portal</a><span class="sep">›</span>
+      const body = `<div class="header"><a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a><span class="sep">›</span>
         <a href="${url('/image_gen')}">🎨 画像生成</a></div>
         <div class="main"><h2>🎨 生成エラー</h2>
           <div class="error">${err?.message ?? 'Unknown error'}<br>
@@ -448,7 +448,7 @@ router.post('/', requireAuth, (req, res) => {
           <p style="margin-top:16px"><a href="${url('/image_gen')}" style="color:#e94560">← 戻る</a></p></div>`;
       return res.send(layout('生成エラー', body));
     }
-    const body = `<div class="header"><a href="${url('/')}">🏭 labo-portal</a><span class="sep">›</span>
+    const body = `<div class="header"><a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a><span class="sep">›</span>
       <a href="${url('/image_gen')}">🎨 画像生成</a></div>
       <div class="main"><h2>🎨 生成完了</h2>
         <div class="img-wrap"><img src="${url('/image_gen/img/' + filename)}" alt="generated">

--- a/src/plugins/rag_admin/index.ts
+++ b/src/plugins/rag_admin/index.ts
@@ -97,6 +97,7 @@ function layout(title: string, body: string): string {
   return `<!DOCTYPE html>
 <html><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 <title>${title} — labo-portal</title>
 <style>
   *{box-sizing:border-box;margin:0;padding:0}
@@ -141,7 +142,7 @@ function headerHtml(sub?: string): string {
   return `<div class="header">
     <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
     <span class="sep">›</span>
-    <a href="${url('/rag_admin')}">🧬 RAG管理</a>
+    <a href="${url('/rag_admin')}">  <i class="fas fa-dna"></i> RAG管理</a>
     ${sub ? `<span class="sep">›</span><span>${sub}</span>` : ''}
   </div>`;
 }
@@ -217,7 +218,7 @@ router.get('/', requireAuth, async (_req, res) => {
   const body = `
     ${headerHtml()}
     <div class="main">
-      <h2>🧬 RAG管理コンソール</h2>
+      <h2><i class="fas fa-dna"></i> RAG管理コンソール</h2>
 
       <div style="display:flex;align-items:center;gap:12px;margin-bottom:20px">
         <span style="color:#888;font-size:.85em">${RAG_URL}</span>
@@ -588,7 +589,7 @@ router.post('/delete-collection', requireAuth, async (req, res) => {
     const body = `
       ${headerHtml('削除エラー')}
       <div class="main">
-        <h2>🧬 削除エラー</h2>
+        <h2><i class="fas fa-dna"></i> 削除エラー</h2>
         <div class="alert alert-err">❌ ${err.message}</div>
         <a href="${url('/rag_admin')}" class="btn btn-primary" style="margin-top:16px;display:inline-block">← 戻る</a>
       </div>`;

--- a/src/plugins/rag_admin/index.ts
+++ b/src/plugins/rag_admin/index.ts
@@ -139,7 +139,7 @@ function layout(title: string, body: string): string {
 
 function headerHtml(sub?: string): string {
   return `<div class="header">
-    <a href="${url('/')}">🏭 labo-portal</a>
+    <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
     <span class="sep">›</span>
     <a href="${url('/rag_admin')}">🧬 RAG管理</a>
     ${sub ? `<span class="sep">›</span><span>${sub}</span>` : ''}
@@ -280,11 +280,11 @@ router.get('/documents', requireAuth, async (req, res) => {
     const body = `
       ${headerHtml('ドキュメント一覧')}
       <div class="main">
-        <h2>📄 ${collection} <span style="color:#888;font-size:.75em">(${total}件)</span></h2>
+        <h2> <i class="fas fa-file-alt"></i> ${collection} <span style="color:#888;font-size:.75em">(${total}件)</span></h2>
         <div class="tabs">
           <a href="${url('/rag_admin')}" class="tab">📚 コレクション</a>
           <a href="${url('/rag_admin/ingest?collection=' + encodeURIComponent(collection))}" class="tab">📥 投入</a>
-          <span class="tab active">📄 ドキュメント</span>
+          <span class="tab active"> <i class="fas fa-file-alt"></i> ドキュメント</span>
         </div>
         <div class="card">
           <div style="display:flex;flex-direction:column;gap:8px">
@@ -316,7 +316,7 @@ router.get('/edit', requireAuth, async (req, res) => {
     const body = `
       ${headerHtml('編集')}
       <div class="main">
-        <h2>✏️ ドキュメント編集</h2>
+        <h2> <i class="fas fa-edit"></i> ドキュメント編集</h2>
         <p style="color:#555;font-family:monospace;font-size:.8em;margin-bottom:16px">${docId}</p>
         <form method="post" action="${url('/rag_admin/update')}">
           <input type="hidden" name="doc_id" value="${docId}">

--- a/src/plugins/rag_admin/index.ts
+++ b/src/plugins/rag_admin/index.ts
@@ -598,7 +598,7 @@ router.post('/delete-collection', requireAuth, async (req, res) => {
 
 export const meta = {
   name: 'RAG管理',
-  icon: '🧬',
+  icon: 'fas fa-dna',
   desc: 'ローカルRAGコンテナの管理・データ投入',
   layer: 'layer2' as const,
   url: '/rag_admin',

--- a/src/plugins/rag_search/index.ts
+++ b/src/plugins/rag_search/index.ts
@@ -63,6 +63,7 @@ function layout(title: string, body: string): string {
   return `<!DOCTYPE html>
 <html><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 <title>${title} — labo-portal</title>
 <style>
   *{box-sizing:border-box;margin:0;padding:0}
@@ -124,10 +125,10 @@ router.get('/', requireAuth, async (req, res) => {
     <div class="header">
       <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
       <span class="sep">›</span>
-      <span>🔍 RAG検索</span>
+      <span>  <i class="fas fa-search"></i> RAG検索</span>
     </div>
     <div class="main">
-      <h2>🔍 RAG検索</h2>
+      <h2>  <i class="fas fa-search"></i> RAG検索</h2>
 
       <div class="source-tabs">
         <a href="${url('/rag')}?source=local" class="source-tab${source==='local'?' active':''}">
@@ -243,10 +244,10 @@ router.post('/', requireAuth, async (req, res) => {
       <div class="header">
         <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
         <span class="sep">›</span>
-        <a href="${url('/rag')}?source=${source}">🔍 RAG検索</a>
+        <a href="${url('/rag')}?source=${source}">  <i class="fas fa-search"></i> RAG検索</a>
       </div>
       <div class="main">
-        <h2>🔍 RAG検索結果</h2>
+        <h2><i class="fas fa-search"></i> RAG検索結果</h2>
         <form method="post" action="${url('/rag')}" style="margin-bottom:20px">
           <input type="hidden" name="source" value="${source}">
           <div class="form-row">
@@ -276,10 +277,10 @@ router.post('/', requireAuth, async (req, res) => {
       <div class="header">
         <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
         <span class="sep">›</span>
-        <a href="${url('/rag')}?source=${source}">🔍 RAG検索</a>
+        <a href="${url('/rag')}?source=${source}">  <i class="fas fa-search"></i> RAG検索</a>
       </div>
       <div class="main">
-        <h2>🔍 RAG検索エラー</h2>
+        <h2><i class="fas fa-search"></i> RAG検索エラー</h2>
         <div class="error"><strong>エラー:</strong> ${err.message}</div>
         <p style="margin-top:16px"><a href="${url('/rag')}?source=${source}" style="color:#e94560">← 戻る</a></p>
       </div>`;

--- a/src/plugins/rag_search/index.ts
+++ b/src/plugins/rag_search/index.ts
@@ -122,7 +122,7 @@ router.get('/', requireAuth, async (req, res) => {
 
   const body = `
     <div class="header">
-      <a href="${url('/')}">🏭 labo-portal</a>
+      <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
       <span class="sep">›</span>
       <span>🔍 RAG検索</span>
     </div>
@@ -241,7 +241,7 @@ router.post('/', requireAuth, async (req, res) => {
 
     const resultBody = `
       <div class="header">
-        <a href="${url('/')}">🏭 labo-portal</a>
+        <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
         <span class="sep">›</span>
         <a href="${url('/rag')}?source=${source}">🔍 RAG検索</a>
       </div>
@@ -274,7 +274,7 @@ router.post('/', requireAuth, async (req, res) => {
   } catch (err: any) {
     const errBody = `
       <div class="header">
-        <a href="${url('/')}">🏭 labo-portal</a>
+        <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
         <span class="sep">›</span>
         <a href="${url('/rag')}?source=${source}">🔍 RAG検索</a>
       </div>

--- a/src/plugins/rag_search/index.ts
+++ b/src/plugins/rag_search/index.ts
@@ -289,7 +289,7 @@ router.post('/', requireAuth, async (req, res) => {
 
 export const meta = {
   name: 'RAG検索',
-  icon: '🔍',
+  icon: 'fas fa-search',
   desc: 'ローカル ChromaDB / HQ pgvector で知識ベースを検索',
   layer: 'layer2' as const,
   url: '/rag',

--- a/src/plugins/services/index.ts
+++ b/src/plugins/services/index.ts
@@ -108,7 +108,7 @@ router.get('/', requireAuth, async (req, res) => {
 
   const body = `
     <div class="header">
-      <a href="${url('/')}">🏭 labo-portal</a>
+      <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
       <span class="sep">›</span>
       <span>⚙️ サービス</span>
     </div>
@@ -160,7 +160,7 @@ router.get('/log', requireAuth, async (req, res) => {
 
   const body = `
     <div class="header">
-      <a href="${url('/')}">🏭 labo-portal</a>
+      <a href="${url('/')}"> <i class="fas fa-industry"></i> labo-portal</a>
       <span class="sep">›</span>
       <a href="${url('/services')}">⚙️ サービス</a>
       <span class="sep">›</span>

--- a/src/plugins/services/index.ts
+++ b/src/plugins/services/index.ts
@@ -97,7 +97,7 @@ router.get('/', requireAuth, async (req, res) => {
 
   const cards = statuses.map(s => `
     <div class="service-card">
-      <div class="svc-icon">${s.icon}</div>
+      <div class="svc-icon"><i class="${s.icon}"></i></div>
       <div class="svc-info">
         <div class="svc-name">${s.name}</div>
         <div class="svc-status ${s.running ? 'on' : 'off'}">${s.running ? '● 稼働中' : '○ 停止中'}</div>

--- a/src/plugins/services/index.ts
+++ b/src/plugins/services/index.ts
@@ -46,6 +46,7 @@ function layout(title: string, body: string): string {
   return `<!DOCTYPE html>
 <html><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 <title>${title} — labo-portal</title>
 <style>
   *{box-sizing:border-box;margin:0;padding:0}

--- a/src/plugins/services/index.ts
+++ b/src/plugins/services/index.ts
@@ -22,14 +22,14 @@ const SERVICES: ServiceDef[] = [
   {
     id: 'labo_portal',
     name: 'labo-portal',
-    icon: '🏭',
+    icon: 'fas fa-industry',
     check: "ps aux | grep 'ts-node.*app.ts' | grep -v grep",
     logFile: '/tmp/labo_portal.log',
   },
   {
     id: 'openclaw',
     name: 'OpenClaw Gateway',
-    icon: '🦀',
+    icon: 'fas fa-cube',
     check: "ps aux | grep 'openclaw' | grep -v grep",
   },
 ];
@@ -177,7 +177,7 @@ router.get('/log', requireAuth, async (req, res) => {
 
 export const meta = {
   name: 'サービス',
-  icon: '⚙️',
+  icon: 'fas fa-cog',
   desc: 'プロセス状態・ログ確認',
   layer: 'core' as const,
   url: '/services',


### PR DESCRIPTION
## 概要
Issue #15 対応のたたき台。UI全体の絵文字アイコンをFont Awesomeに統一。

## 変更内容
- ✅ app.ts: Font Awesome CDN追加
- ✅ プラグインmeta.icon 統一（🖼→fas fa-images等）
- ✅ HTML内絵文字を一括置換（📁→folder, 🗑→trash等）

## 備考
- 一括置換のため、細部調整は別途対応予定
- 方向性を示すたたき台として作成

Related: #15