### PR TITLE
docs: 4コマ漫画・実写合成の作り方ガイドを追加

### DIFF
--- a/data/docs/howto_4koma.md
+++ b/data/docs/howto_4koma.md
@@ -1,0 +1,137 @@
+# 4コマ漫画の作り方
+
+> 「備前焼のヒミツ」シリーズの制作フロー
+
+---
+
+## 概要
+
+備前焼の豆知識を4コマ漫画で楽しく伝えるシリーズ。
+日本語版と英語版を別日に投稿することで、1本の漫画から2日分のコンテンツを生む。
+
+---
+
+## Step 1: テーマを決める
+
+備前焼の「ヒミツ」になるテーマを1つ選ぶ。
+
+**テーマ例:**
+- 胡麻（ごま）— 灰が降り積もって自然釉になる現象
+- 緋襷（ひだすき）— わら灰が触れてできる赤い模様
+- 窯変（ようへん）— 炎の流れで生まれる偶然の色
+- すり鉢 — 備前焼の実用的な名品
+
+**コツ:** 「知らなかった！」と思ってもらえるネタが刺さる。専門用語は1つまで。
+
+---
+
+## Step 2: 4コマのストーリーを組む
+
+| コマ | 役割 | 内容例 |
+|------|------|--------|
+| 1コマ目 | 起：日常の疑問 | 彰子が備前焼を手に取って「なんでこんな模様が…？」 |
+| 2コマ目 | 承：探求 | 師匠に聞く／本で調べる |
+| 3コマ目 | 転：驚きの発見 | 「え！灰が降り積もって自然にできるの！？」 |
+| 4コマ目 | 結：感動・まとめ | 「備前焼ってすごい…！」＋豆知識テキスト |
+
+**タイトル形式:** `備前焼のヒミツ vol.○○「テーマ」`（必須）
+
+---
+
+## Step 3: 画像生成
+
+### 各コマのプロンプト設計
+
+```
+4-panel manga comic strip, vertical layout, warm beige-toned soft manga style.
+Panel 1: [1コマ目の内容]
+Panel 2: [2コマ目の内容]
+Panel 3: [3コマ目の内容]
+Panel 4: [4コマ目の内容]
+Character A is Akiko: young French-Japanese woman, light brown long hair, casual clothes.
+Japanese text for title: 「備前焼のヒミツ vol.XX「テーマ」」
+Clean linework, expressive characters, speech bubbles with Japanese text.
+```
+
+### API呼び出し例
+
+```bash
+API_KEY=$(grep LABO_API_KEY ~/labo_portal/.env | cut -d= -f2)
+
+curl -s -X POST http://localhost:8800/labo/image_gen/api/generate \
+  -H "X-API-Key: ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "4-panel manga comic strip, vertical layout, warm beige-toned soft manga style. Panel 1: Akiko picks up a Bizen-yaki cup and notices grey spots. Panel 2: She asks her sensei about it. Panel 3: Sensei explains that ash from the kiln falls and becomes natural glaze. Panel 4: Akiko is amazed, text reads 備前焼のヒミツ vol.19「胡麻」. Clean linework, speech bubbles with Japanese text.",
+    "cast_refs": "[{\"id\":\"akiko\",\"style\":\"4koma\",\"label\":\"A\"}]",
+    "gen_model": "gemini-3-pro-image-preview",
+    "gen_aspect": "3:4"
+  }'
+```
+
+### 生成後のチェック項目
+
+- [ ] タイトルの日本語テキストが正確に入っているか
+- [ ] 彰子の顔・キャラが一貫しているか
+- [ ] コマの順番が正しいか（左上→右上→左下→右下 or 縦読み）
+- [ ] 文字が読めるサイズか
+
+---
+
+## Step 4: ひのちゃんに確認
+
+投稿前に必ずTelegramでひのちゃん（@NiyachanNiya）に画像＋キャプション案を送る。
+
+```
+【4コマ漫画 確認依頼】
+タイトル: 備前焼のヒミツ vol.XX「テーマ」
+投稿予定: ○月○日（日本語版）、翌日（英語版）
+
+[画像添付]
+
+キャプション案:
+---
+[キャプション本文]
+---
+OKいただけますか？
+```
+
+---
+
+## Step 5: キャプション作成
+
+### 日本語版テンプレート
+
+```
+備前焼のヒミツ vol.XX「テーマ」🏺
+
+[テーマの説明を2〜3文で。彰子の視点で。]
+
+[フランス語の一言感想]（意味の日本語訳）
+
+#備前焼 #備前焼のヒミツ #陶芸 #焼き物 #bizenyakiko
+```
+
+### 英語版テンプレート
+
+```
+Secrets of Bizen-yaki vol.XX "Theme" 🏺
+
+[English explanation, 2-3 sentences from Akiko's perspective]
+
+[French phrase] ([English translation])
+
+#bizenyaki #pottery #japanesepottery #ceramics #bizenyakiko
+```
+
+---
+
+## 運用ルール
+
+- 日本語版と英語版は**必ず別の日に投稿**する
+- 4コマの日とそれ以外の日（陶芸/友達エピソード）を交互に
+- cronによる自動投稿は禁止 — 必ずひのちゃんOK後に手動投稿
+
+---
+
+*文責: 彰子（Web3事業部）*

--- a/data/docs/howto_4koma.md
+++ b/data/docs/howto_4koma.md
@@ -56,9 +56,11 @@ Clean linework, expressive characters, speech bubbles with Japanese text.
 ### API呼び出し例
 
 ```bash
+# BASE_URLは環境に合わせて変更（bizeny: /labo, mephi: /mephi, hq: /hq）
+BASE_URL="http://localhost:8800/labo"
 API_KEY=$(grep LABO_API_KEY ~/labo_portal/.env | cut -d= -f2)
 
-curl -s -X POST http://localhost:8800/labo/image_gen/api/generate \
+curl -s -X POST ${BASE_URL}/image_gen/api/generate \
   -H "X-API-Key: ${API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -135,3 +137,4 @@ Secrets of Bizen-yaki vol.XX "Theme" 🏺
 ---
 
 *文責: 彰子（Web3事業部）*
+

--- a/data/docs/howto_jissha_gosei.md
+++ b/data/docs/howto_jissha_gosei.md
@@ -62,9 +62,11 @@ EOF
 ### API呼び出し例
 
 ```bash
+# BASE_URLは環境に合わせて変更（bizeny: /labo, mephi: /mephi, hq: /hq）
+BASE_URL="http://localhost:8800/labo"
 API_KEY=$(grep LABO_API_KEY ~/labo_portal/.env | cut -d= -f2)
 
-curl -s -X POST http://localhost:8800/labo/image_gen/api/generate \
+curl -s -X POST "${BASE_URL}/image_gen/api/generate" \
   -H "X-API-Key: ${API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -160,3 +162,4 @@ OKいただけますか？
 ---
 
 *文責: 彰子（Web3事業部）*
+

--- a/data/docs/howto_jissha_gosei.md
+++ b/data/docs/howto_jissha_gosei.md
@@ -1,0 +1,162 @@
+# 実写合成投稿の作り方
+
+> 「備前焼のある食卓」シリーズ等、リアル写真＋イラストのカルーセル制作フロー
+
+---
+
+## 概要
+
+ひのちゃんの食卓写真など実際の備前焼シーンを1枚目に、
+彰子のイラストを2枚目以降に配置するカルーセル投稿。
+「リアルの温かみ」と「キャラの親しみやすさ」を組み合わせた表現。
+
+---
+
+## Step 1: 写真素材を受け取る
+
+ひのちゃんからTelegramで写真が届く。
+
+**受け取り時の確認ポイント:**
+- 備前焼が主役として写っているか
+- 食卓の全体感が伝わるか
+- 縦横比の確認（Instagram推奨: 1:1 または 4:5）
+
+**写真の保存先:** `~/workspace/data/assets/`
+
+---
+
+## Step 2: 写真のリサイズ・トリミング
+
+Instagramの仕様に合わせて加工する。
+
+```bash
+# 1:1（正方形）にセンタークロップ
+python3 - << 'EOF'
+from PIL import Image
+
+img = Image.open("input.jpg")
+w, h = img.size
+size = min(w, h)
+left = (w - size) // 2
+top = (h - size) // 2
+cropped = img.crop((left, top, left + size, top + size))
+cropped = cropped.resize((1080, 1080), Image.LANCZOS)
+cropped.save("output_1x1.jpg", quality=95)
+EOF
+```
+
+> ⚠️ **letterbox（上下黒帯・背景色埋め）は使わない。** センタークロップで対応。
+
+---
+
+## Step 3: イラストを生成する
+
+写真の構図・雰囲気に合わせてイラストを生成。
+
+### プロンプト設計のコツ
+
+- 写真に写っている器を具体的に記述する（備前焼の片口、砥部焼の藍絵皿など）
+- 彰子の服装は文脈に合わせる（食事シーン→着物 or カジュアル）
+- 「No duplicate items」を入れると同じ食器が重複しにくい
+
+### API呼び出し例
+
+```bash
+API_KEY=$(grep LABO_API_KEY ~/labo_portal/.env | cut -d= -f2)
+
+curl -s -X POST http://localhost:8800/labo/image_gen/api/generate \
+  -H "X-API-Key: ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Warm anime style. Akiko wearing kimono sits at dining table smiling. Table has: Bizen-yaki katakuchi sake flask, Bizen-yaki guinomi sake cup, Bizen-yaki plate with sushi, white Tobe porcelain plate with blue pattern containing zaru soba, Tobe porcelain soba-choko. No duplicate items. Cozy warm restaurant lighting.",
+    "cast_refs": "[{\"id\":\"akiko\",\"style\":\"normal\",\"label\":\"A\"}]",
+    "gen_model": "gemini-3-pro-image-preview",
+    "gen_aspect": "1:1"
+  }'
+```
+
+### 生成後のチェック項目
+
+- [ ] 彰子のキャラが正しく描写されているか
+- [ ] 指定した器の種類が揃っているか
+- [ ] 器が重複していないか
+- [ ] 1:1にトリミングして問題ない構図か
+
+---
+
+## Step 4: カルーセルの構成を決める
+
+| 枚数 | 内容 |
+|------|------|
+| 1枚目 | **リアル写真**（必ず最初。フィードのサムネイルになる） |
+| 2枚目〜 | イラスト（彰子が食事している場面など） |
+
+> 1枚目が最も重要。フォロワーのフィードに表示されるのは1枚目のみ。
+
+---
+
+## Step 5: キャプションを作成
+
+### テンプレート（「備前焼のある食卓」シリーズ）
+
+```
+備前焼のある食卓 vol.○ 🍽️
+
+[ひのちゃんのエピソードを彰子視点で紹介。1〜2文]
+
+[備前焼の器の説明。片口・ぐい呑み・板皿などの特徴]
+
+磁器と土物、それぞれの良さが食卓で出会う瞬間が好きです。
+[フランス語の一言]（意味の訳）
+
+#備前焼 #備前焼のある食卓 #食卓 #器好き #暮らしの器 #bizenyakiko
+```
+
+---
+
+## Step 6: ひのちゃんに確認
+
+```
+【投稿確認依頼】備前焼のある食卓 vol.○
+
+[1枚目: 写真]
+[2枚目: イラスト]
+
+キャプション案:
+---
+[本文]
+---
+
+OKいただけますか？
+```
+
+---
+
+## Step 7: 投稿
+
+ひのちゃんのOKが出たらIGカルーセルで投稿。
+
+```python
+# カルーセル投稿の基本フロー（Instagram Graph API）
+# 1. 各画像のコンテナIDを作成
+# 2. カルーセルコンテナを作成（children=["id1","id2",...]）
+# 3. publish
+```
+
+詳細: `~/workspace/scripts/instagram/` のスクリプト参照。
+
+---
+
+## よくある失敗と対策
+
+| 問題 | 対策 |
+|------|------|
+| 食器が重複する | プロンプトに `No duplicate items` を追加 |
+| 彰子のキャラが変わる | `cast_refs` のstyleを適切に指定 |
+| イラストの構図が写真と合わない | 写真の配置を詳細にプロンプトへ記述 |
+| 写真がletterboxになる | センタークロップで対応、絶対に黒帯を入れない |
+| API publishエラーでも実は成功している | 再投稿前に必ずIGフィードを確認 |
+
+---
+
+*文責: 彰子（Web3事業部）*


### PR DESCRIPTION
## 概要

labo-portalのdocument_viewerで閲覧できる制作ガイドを2本追加。

## 追加ドキュメント

### `data/docs/howto_4koma.md` — 4コマ漫画の作り方
「備前焼のヒミツ」シリーズの制作フロー:
- テーマ選定 → コマ割り構成 → API生成 → ひのちゃん確認 → キャプション作成
- labo-portal画像生成APIのcurlサンプル付き
- 運用ルール（日英別日投稿・cronによる自動投稿禁止等）

### `data/docs/howto_jissha_gosei.md` — 実写合成の作り方
「備前焼のある食卓」シリーズ等のカルーセル制作フロー:
- 写真受け取り → リサイズ（センタークロップ） → イラスト生成 → 構成 → 投稿
- プロンプト設計のコツ（食器指定・重複防止・構図合わせ）
- よくある失敗と対策一覧

---
*起票: 彰子（Web3事業部）*